### PR TITLE
feat: chainable validators

### DIFF
--- a/src/tests/validators.test.ts
+++ b/src/tests/validators.test.ts
@@ -206,4 +206,42 @@ describe('Validators', () => {
       ).toBe(false);
     });
   });
+
+  describe.only('chain', () => {
+    test('validates a chain', () => {
+      const validator = Validators.chainable()
+        .chain(Validators.string)
+        .chain(Validators.pattern(/[a-z]+@gmail.com$/i));
+      expect(validator('edede@gmail.com')).toBe(true);
+    });
+
+    test('validates a chain with typed params', () => {
+      const validator = Validators.chainable()
+        .chain(Validators.string)
+        // at this point I know it's a string
+        .chain<string>((v) => v.length > 10)
+        .chain(
+          Validators.pattern(
+            /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/i
+          )
+        )
+        .chain(Validators.date);
+
+      expect(validator('2020-01-01T00:00:00Z')).toBe(true);
+      expect(validator('2020-01-01T00:00:00')).toBe(false);
+    });
+
+    test('complex types', () => {
+      const validator = Validators.chainable()
+        .chain(Validators.arrayOf(Validators.number))
+        // at this point I know it's a string
+        .chain<number[]>((v) => v.length > 2)
+        .chain<number[]>((v) => v.every((n) => n % 2 === 0));
+
+      expect(validator(['string', 'string', 'string', 1, 2, 3])).toBe(false);
+      expect(validator(['string', 'string', 1, 2])).toBe(false);
+      expect(validator([1, 2, 3])).toBe(false);
+      expect(validator([2, 4, 6])).toBe(true);
+    });
+  });
 });

--- a/src/tests/validators.test.ts
+++ b/src/tests/validators.test.ts
@@ -207,36 +207,36 @@ describe('Validators', () => {
     });
   });
 
-  describe.only('chain', () => {
+  describe.only('makeChain', () => {
     test('validates a chain', () => {
-      const validator = Validators.chainable()
-        .chain(Validators.string)
-        .chain(Validators.pattern(/[a-z]+@gmail.com$/i));
+      const validator = Validators.makeChain()
+        .link(Validators.string)
+        .link(Validators.pattern(/[a-z]+@gmail.com$/i));
       expect(validator('edede@gmail.com')).toBe(true);
     });
 
     test('validates a chain with typed params', () => {
-      const validator = Validators.chainable()
-        .chain(Validators.string)
+      const validator = Validators.makeChain()
+        .link(Validators.string)
         // at this point I know it's a string
-        .chain<string>((v) => v.length > 10)
-        .chain(
+        .link<string>((v) => v.length > 10)
+        .link(
           Validators.pattern(
             /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/i
           )
         )
-        .chain(Validators.date);
+        .link(Validators.date);
 
       expect(validator('2020-01-01T00:00:00Z')).toBe(true);
       expect(validator('2020-01-01T00:00:00')).toBe(false);
     });
 
     test('complex types', () => {
-      const validator = Validators.chainable()
-        .chain(Validators.arrayOf(Validators.number))
+      const validator = Validators.makeChain()
+        .link(Validators.arrayOf(Validators.number))
         // at this point I know it's a string
-        .chain<number[]>((v) => v.length > 2)
-        .chain<number[]>((v) => v.every((n) => n % 2 === 0));
+        .link<number[]>((v) => v.length > 2)
+        .link<number[]>((v) => v.every((n) => n % 2 === 0));
 
       expect(validator(['string', 'string', 'string', 1, 2, 3])).toBe(false);
       expect(validator(['string', 'string', 1, 2])).toBe(false);

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,3 +1,6 @@
+import { ValidationChain } from './validation-chain';
+import { TypedValidator, ValidatorOp } from './types';
+
 /**
  * Ensure a given argument is an array using `Array.isArray`.
  */
@@ -116,9 +119,32 @@ export const combine: ValidatorOp =
 export const optional: ValidatorOp = (validatorFn) => (arg) =>
   nullish(arg) ? true : validatorFn(arg);
 
-type Validator = (arg: unknown) => boolean;
-type TypedValidator<T = unknown> = (arg: unknown) => arg is T;
-
-type ValidatorOp = (
-  ...validatorFn: (Validator | TypedValidator)[]
-) => Validator;
+/**
+ * Creates a chainable structure for running multiple validations
+ * in series. In contrast to the {@link combine} function which
+ * combines all inputs with `&&`, this function will bail out
+ * on the first failure.
+ *
+ * @example
+ * A simple chain to verify a string is a date.
+ * ```ts
+ * const isValidDateString = Validators.chainable()
+ *  .chain(Validators.string)
+ *  .chain(Validators.date);
+ *
+ * const isValidDate = isValidDateString('2021-01-01'); // true
+ * ```
+ *
+ * @example
+ * Dealing with complex types is also supported via Generics.
+ *
+ * ```ts
+ * const isValidUser = Validators.chainable()
+ *  .chain(Validators.object)
+ *  .chain<Record<string, unknown>>(obj => obj.hasOwnProperty('name'))
+ *  .chain<{ name: string }>(({ name }) => Validators.pattern(/^[a-z]+$/i)(name))
+ * ```
+ */
+export function chainable() {
+  return new ValidationChain();
+}

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -128,9 +128,9 @@ export const optional: ValidatorOp = (validatorFn) => (arg) =>
  * @example
  * A simple chain to verify a string is a date.
  * ```ts
- * const isValidDateString = Validators.chainable()
- *  .chain(Validators.string)
- *  .chain(Validators.date);
+ * const isValidDateString = Validators.makeChain()
+ *  .link(Validators.string)
+ *  .link(Validators.date);
  *
  * const isValidDate = isValidDateString('2021-01-01'); // true
  * ```
@@ -139,12 +139,12 @@ export const optional: ValidatorOp = (validatorFn) => (arg) =>
  * Dealing with complex types is also supported via Generics.
  *
  * ```ts
- * const isValidUser = Validators.chainable()
- *  .chain(Validators.object)
- *  .chain<Record<string, unknown>>(obj => obj.hasOwnProperty('name'))
- *  .chain<{ name: string }>(({ name }) => Validators.pattern(/^[a-z]+$/i)(name))
+ * const isValidUser = Validators.makeChain()
+ *  .link(Validators.object)
+ *  .link<Record<string, unknown>>(obj => obj.hasOwnProperty('name'))
+ *  .link<{ name: string }>(({ name }) => Validators.pattern(/^[a-z]+$/i)(name))
  * ```
  */
-export function chainable() {
+export function makeChain() {
   return new ValidationChain();
 }

--- a/src/validators/types.ts
+++ b/src/validators/types.ts
@@ -1,0 +1,6 @@
+export type Validator = (arg: unknown) => boolean;
+export type TypedValidator<T = unknown> = (arg: unknown) => arg is T;
+
+export type ValidatorFn<T = unknown> = Validator | TypedValidator<T>;
+
+export type ValidatorOp = (...validatorFn: ValidatorFn[]) => Validator;

--- a/src/validators/validation-chain.ts
+++ b/src/validators/validation-chain.ts
@@ -1,0 +1,51 @@
+import { TypedValidator, ValidatorFn } from './types';
+
+type ChainableValidator<T> = TypedValidator<T> & {
+  chain: <Y>(fn: (arg: Y) => boolean) => ChainableValidator<Y>;
+};
+
+export class ValidationChain {
+  private head: Node | null = null;
+  private tail: Node | null = null;
+
+  public chain<T = unknown, I = unknown>(
+    fn: (arg: I) => boolean
+  ): ChainableValidator<T> {
+    const node = new Node(fn as ValidatorFn);
+
+    if (!this.head) {
+      this.head = node;
+      this.tail = this.head;
+    }
+
+    this.tail?.connect(node);
+    this.tail = node;
+
+    const call = (arg: unknown): arg is T => this.validate<T>(arg);
+    return Object.assign(call, {
+      chain: this.chain.bind(this),
+    });
+  }
+
+  private validate<T>(arg: unknown): arg is T {
+    let current = this.head;
+
+    while (current) {
+      if (!current.validator || !current.validator(arg)) {
+        return false;
+      }
+      current = current.next;
+    }
+
+    return true;
+  }
+}
+
+class Node {
+  constructor(public validator: ValidatorFn, public next: Node | null = null) {}
+
+  public connect(next: Node) {
+    this.next = next;
+    return next;
+  }
+}

--- a/src/validators/validation-chain.ts
+++ b/src/validators/validation-chain.ts
@@ -1,14 +1,14 @@
 import { TypedValidator, ValidatorFn } from './types';
 
 type ChainableValidator<T> = TypedValidator<T> & {
-  chain: <Y>(fn: (arg: Y) => boolean) => ChainableValidator<Y>;
+  link: <Y>(fn: (arg: Y) => boolean) => ChainableValidator<Y>;
 };
 
 export class ValidationChain {
   private head: Node | null = null;
   private tail: Node | null = null;
 
-  public chain<T = unknown, I = unknown>(
+  public link<T = unknown, I = unknown>(
     fn: (arg: I) => boolean
   ): ChainableValidator<T> {
     const node = new Node(fn as ValidatorFn);
@@ -23,7 +23,7 @@ export class ValidationChain {
 
     const call = (arg: unknown): arg is T => this.validate<T>(arg);
     return Object.assign(call, {
-      chain: this.chain.bind(this),
+      link: this.link.bind(this),
     });
   }
 


### PR DESCRIPTION
Introduces a new type of validator via the `Validators.makeChain` method. This new validator type can be used to combine validators in a chained structure. This is different from the existing `Validator.combine` method which takes an array of validators and executes each one until any fails.

The main difference between the two methods is that with combine, you are not able to leverage complex or intermediary types. Take the following example:

```ts
import { Validators } from '@ededejr/validate';

const date = Validators.combine(Validators.string, (v) => (new Date(v)).toString() !== "Invalid Date")
```

This example will fail as `v` must first be validated as a string before continuing on to validate that the string is a date. Using the new chainable validator provides an escape hatch for this kind of functionality:

```ts
import { Validators } from '@ededejr/validate';

const date = Validators.makeChain()
    .link(Validators.string)
    // at this point we are sure `v` is a string
    .link<string>(v => (new Date(v)).toString() !== "Invalid Date")
```

In a future version I hope to make the return type inferred to remove the need for the generic